### PR TITLE
Return attributes as part of the assertion

### DIFF
--- a/lib/simple_saml/assertion.ex
+++ b/lib/simple_saml/assertion.ex
@@ -215,8 +215,8 @@ defmodule SimpleSaml.Assertion do
   end
 
   defp extract_attributes(node) do
-    with {:ok, attributes_node} <- XmlNode.first_child(node, "*:AttributeStatement") do
-      XmlNode.children(attributes_node, "*:Attribute")
+    with {:ok, attributes_node} <- XmlNode.first_child(node, ~r/.*:?AttributeStatement$/) do
+      XmlNode.children(attributes_node, ~r/.*:?Attribute$/)
       |> Enum.flat_map(fn attribute_node ->
         with {:ok, name} <- XmlNode.attribute(attribute_node, "Name") do
           values = extract_attribute_values(attribute_node)
@@ -232,7 +232,7 @@ defmodule SimpleSaml.Assertion do
   end
 
   defp extract_attribute_values(attribute_node) do
-    XmlNode.children(attribute_node, "*:AttributeValue")
+    XmlNode.children(attribute_node, ~r/.*:?AttributeValue$/)
     |> Enum.flat_map(fn value_node ->
       # Check if the value_node contains any child XML elements and skip if it
       # does, because then it's not just a simple text node.

--- a/lib/simple_saml/simple_saml.ex
+++ b/lib/simple_saml/simple_saml.ex
@@ -56,6 +56,11 @@ defmodule SimpleSaml do
       iex> {:ok, {_root, assertion}} = SimpleSaml.parse_response(saml_response)
       iex> assertion
       %SimpleSaml.Assertion{
+        attributes: %{
+          "email" => ["adrian+onelogin@todo.computer"],
+          "first_name" => ["Adrian"],
+          "last_name" => ["Gruntkowski"]
+        },
         audience: "https://samltest.todo.computer",
         issuer: "https://app.onelogin.com/saml/metadata/183993d8-a07b-465c-9c7a-9d00898c4608",
         name_id: "adrian+onelogin@todo.computer",

--- a/lib/simple_saml/simple_saml.ex
+++ b/lib/simple_saml/simple_saml.ex
@@ -41,6 +41,17 @@ defmodule SimpleSaml do
       iex> {:ok, {_root, assertion}} = SimpleSaml.parse_response(saml_response)
       iex> assertion
       %SimpleSaml.Assertion{
+        attributes: %{
+          "http://schemas.microsoft.com/claims/authnmethodsreferences" => ["http://schemas.microsoft.com/ws/2008/06/identity/authenticationmethod/password", "http://schemas.microsoft.com/claims/multipleauthn", "http://schemas.microsoft.com/ws/2008/06/identity/authenticationmethod/unspecified"],
+          "http://schemas.microsoft.com/identity/claims/displayname" => ["Adrian Gruntkowski"],
+          "http://schemas.microsoft.com/identity/claims/identityprovider" => ["live.com"],
+          "http://schemas.microsoft.com/identity/claims/objectidentifier" => ["2bcdc4a9-e20d-4375-92a0-1548e5241651"],
+          "http://schemas.microsoft.com/identity/claims/tenantid" => ["8e4dae73-8586-43f1-8e9b-8e5a09949050"],
+          "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" => ["adrian.gruntkowski@gmail.com"],
+          "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname" => ["Adrian"],
+          "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" => ["adrian.gruntkowski_gmail.com#EXT#@adriangruntkowskigmail.onmicrosoft.com"],
+          "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname" => ["Gruntkowski"]
+        },
         audience: "https://samltest.todo.computer",
         issuer: "https://sts.windows.net/8e4dae73-8586-43f1-8e9b-8e5a09949050/",
         name_id: "adrian.gruntkowski_gmail.com#EXT#@adriangruntkowskigmail.onmicrosoft.com",


### PR DESCRIPTION
It's very useful to have the attributes as part of the assertion, to save writing more code to reach into the XML and go rooting around. Since each attribute can have multiple values, I've chosen to return the attributes as a list of strings.